### PR TITLE
增加ionic:build:before ENV参数

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "lint": "ionic-app-scripts lint",
     "ionic:build": "ionic-app-scripts build",
     "ionic:serve": "ionic-app-scripts serve",
-    "ionic:build:before": "node ./config/env-script.js",
+    "ionic:build:before": "ENV=prod node ./config/env-script.js",
     "ionic:watch:before": "node ./config/env-script.js"
   },
   "dependencies": {


### PR DESCRIPTION
运行ionic build 读取的依旧是dev.ts 
在ionic:build:before 中配置的ENV=prod 的参数 
